### PR TITLE
v0.1.6.1: Build with GHC 9.2: adapt to ghc-prim-0.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.1
+# version: 0.14.3
 #
-# REGENDATA ("0.14.1",["github","http-io-streams.cabal"])
+# REGENDATA ("0.14.3",["github","http-io-streams.cabal"])
 #
 name: Haskell-CI
 on:
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.2
+            compilerKind: ghc
+            compilerVersion: 9.2.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.0.2
             compilerKind: ghc
             compilerVersion: 9.0.2
@@ -91,7 +96,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
@@ -102,7 +107,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME" libbrotli-dev
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 See also http://pvp.haskell.org/faq
 
+### 0.1.6.1
+
+* Build with GHC 9.2 and `ghc-prim-0.8` (via `base-4.16`).
+
 ### 0.1.6.0
 
 * New function `openConnectionAddress''` supporting supplying local `SSLContext`s as well as modifying the `SSL` connection before initiating the client SSL handshake.
@@ -13,7 +17,7 @@ See also http://pvp.haskell.org/faq
 ### 0.1.4.0
 
 * New module `Network.Http.Client.WebSocket` providing basic RFC6455 support.
-* New function 'inputStreamBodyChunked' supporting breaking up over-sized chunks.
+* New function `inputStreamBodyChunked` supporting breaking up over-sized chunks.
 
 ### 0.1.3.0
 

--- a/http-io-streams.cabal
+++ b/http-io-streams.cabal
@@ -1,7 +1,6 @@
 cabal-version:       2.2
 name:                http-io-streams
-version:             0.1.6.0
-x-revision:          3
+version:             0.1.6.1
 
 synopsis:            HTTP and WebSocket client based on io-streams
 description:
@@ -23,6 +22,7 @@ bug-reports:         https://github.com/hvr/http-io-streams/issues
 extra-source-files:  CHANGELOG.md
 
 tested-with:
+  GHC == 9.2.2
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4
@@ -51,13 +51,24 @@ flag fast-xor
 
 common settings
   build-depends:
-    , base                 >= 4.5 && < 4.16
+    , base                 >= 4.5 && < 4.17
     , blaze-builder       ^>= 0.4.1.0
-    , bytestring          ^>= 0.10.0.0
+    , bytestring           >= 0.10.0.0 && < 0.12
     , case-insensitive    ^>= 1.2.0.11
     , containers          ^>= 0.5.0.0 || ^>= 0.6.0.1
 
   default-language:  Haskell2010
+  other-extensions:
+    BangPatterns
+    CPP
+    DeriveDataTypeable
+    DoAndIfThenElse
+    MagicHash
+    NamedFieldPuns
+    OverloadedStrings
+    Rank2Types
+    RecordWildCards
+    UnboxedTuples
 
   ghc-options:
     -Wall
@@ -106,9 +117,7 @@ library
 
   -- http-common
   build-depends:
-    , base64-bytestring   ^>= 1.1.0.0 || ^>= 1.2.1.0
-        -- r3: undo revision of the lower bound of base64-bytestring in r1;
-        -- a bump to just ^>= 1.2.1.0 should wait for a re-release.
+    , base64-bytestring   ^>= 1.2.1.0
     , mtl                 ^>= 2.2.2
 
   hs-source-dirs: http-common/lib

--- a/http-streams/lib/Network/Http/Inconvenience.hs
+++ b/http-streams/lib/Network/Http/Inconvenience.hs
@@ -62,7 +62,10 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Data.Typeable (Typeable)
 import Data.Word (Word16)
-import GHC.Exts (Int(..),word2Int#, uncheckedShiftRL#)
+import GHC.Exts (Int(..), word2Int#, uncheckedShiftRL#)
+#if MIN_VERSION_base(4,16,0)
+import GHC.Exts (word8ToWord#)
+#endif
 import GHC.Word (Word8 (..))
 import Network.URI (URI (..), URIAuth (..), isAbsoluteURI,
                     parseRelativeReference, parseURI, uriToString)
@@ -135,9 +138,11 @@ hexd c0 = Builder.fromWord8 (c2w '%') `mappend` Builder.fromWord8 hi
     toDigit   = c2w . intToDigit
     !low      = toDigit $ fromEnum $ c .&. 0xf
     !hi       = toDigit $ (c .&. 0xf0) `shiftr` 4
-
+#if MIN_VERSION_base(4,16,0)
+    shiftr (W8# a#) (I# b#) = I# (word2Int# (uncheckedShiftRL# (word8ToWord# a#) b#))
+#else
     shiftr (W8# a#) (I# b#) = I# (word2Int# (uncheckedShiftRL# a# b#))
-
+#endif
 
 urlEncodeTable :: Set Char
 urlEncodeTable = Set.fromList $! filter f $! map w2c [0..255]


### PR DESCRIPTION
v0.1.6.1: Build with GHC 9.2: adapt to ghc-prim-0.8