### PR TITLE
Fix #5: Turn tests/check.hs into a cabal test-suite

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -138,7 +138,7 @@ jobs:
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 70600 && HCNUMVER < 90000)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -242,6 +242,9 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
+      - name: tests
+        run: |
+          if [ $((HCNUMVER >= 70600 && HCNUMVER < 90000)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_http_io_streams} || false

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,8 @@
 apt: libbrotli-dev
 
 installed: -all
+
+-- Andreas Abel, 2022-03-30:
+-- The `snap` framework does not build on GHC 9.x yet.
+-- On GHC 7.4, it has conflicting constraints with the other dependencies.
+tests: >= 7.6 && < 9.0

--- a/http-io-streams.cabal
+++ b/http-io-streams.cabal
@@ -19,7 +19,16 @@ maintainer:          Herbert Valerio Riedel <hvr@gnu.org>
 copyright:           © 2012-2018 Operational Dynamics Consulting, Pty Ltd and Others
 category:            Web, IO-Streams
 bug-reports:         https://github.com/hvr/http-io-streams/issues
-extra-source-files:  CHANGELOG.md
+
+extra-source-files:
+  CHANGELOG.md
+  tests/example1.txt
+  tests/example2.txt
+  tests/example3.txt
+  tests/example4.txt
+  tests/example5.txt
+  tests/hello.html
+  tests/statler.jpg
 
 tested-with:
   GHC == 9.2.2
@@ -52,10 +61,21 @@ flag fast-xor
 common settings
   build-depends:
     , base                 >= 4.5 && < 4.17
+    , attoparsec          ^>= 0.13.2.2 || ^>= 0.14.4
+    , base64-bytestring   ^>= 1.2.1.0
     , blaze-builder       ^>= 0.4.1.0
     , bytestring           >= 0.10.0.0 && < 0.12
     , case-insensitive    ^>= 1.2.0.11
     , containers          ^>= 0.5.0.0 || ^>= 0.6.0.1
+    , directory           ^>= 1.2.0.1 || ^>= 1.3.0.0
+    , HsOpenSSL           ^>= 0.11.2
+    , io-streams          ^>= 1.5.0.1
+    , mtl                 ^>= 2.2.2
+    , network             ^>= 2.6.0.0 || ^>= 2.7.0.0 || ^>= 2.8.0.0 || ^>= 3.0.0.0 || ^>= 3.1.0.0
+    , network-uri         ^>= 2.6.0.0
+    , openssl-streams     ^>= 1.2.1.3
+    , text                ^>= 1.2.3.0
+    , transformers        ^>= 0.3.0.0 || ^>= 0.4.2.0 || ^>= 0.5.2.0
 
   default-language:  Haskell2010
   other-extensions:
@@ -93,17 +113,8 @@ library
       brotli-streams      ^>= 0.0.0.0
 
   build-depends:
-    , HsOpenSSL           ^>= 0.11.2
-    , attoparsec          ^>= 0.13.2.2 || ^>= 0.14.4
     , binary              ^>= 0.7.1   || ^>= 0.8.3
     , cryptohash-sha1     ^>= 0.11.100
-    , directory           ^>= 1.2.0.1 || ^>= 1.3.0.0
-    , io-streams          ^>= 1.5.0.1
-    , network             ^>= 2.6.0.0 || ^>= 2.7.0.0 || ^>= 2.8.0.0 || ^>= 3.0.0.0 || ^>= 3.1.0.0
-    , network-uri         ^>= 2.6.0.0
-    , openssl-streams     ^>= 1.2.1.3
-    , text                ^>= 1.2.3.0
-    , transformers        ^>= 0.3.0.0 || ^>= 0.4.2.0 || ^>= 0.5.2.0
 
   hs-source-dirs: http-streams/lib
   exposed-modules:
@@ -115,13 +126,46 @@ library
     Network.Http.Utilities
     Network.Http.Inconvenience
 
-  -- http-common
-  build-depends:
-    , base64-bytestring   ^>= 1.2.1.0
-    , mtl                 ^>= 2.2.2
-
   hs-source-dirs: http-common/lib
   other-modules:
     Network.Http.Types
     Network.Http.RequestBuilder,
     Network.Http.Internal
+
+
+test-suite test
+  import: settings
+  type:   exitcode-stdio-1.0
+
+  hs-source-dirs:
+    http-common/lib
+    http-streams/lib
+    tests
+  main-is:
+    check.hs
+  other-modules:
+    MockServer
+    TestSuite
+    Network.Http.Client
+    Network.Http.Connection
+    Network.Http.Inconvenience
+    Network.Http.Internal
+    Network.Http.RequestBuilder
+    Network.Http.ResponseParser
+    Network.Http.Types
+    Network.Http.Utilities
+
+  build-depends:
+      -- http-io-streams
+    , aeson
+    , aeson-pretty
+    , hspec
+    , hspec-expectations
+    , HUnit
+    , lifted-base
+    , snap
+    , snap-core
+    , snap-server
+    , system-filepath
+    , system-fileio
+    , unordered-containers

--- a/tests/BaselinePoint.hs
+++ b/tests/BaselinePoint.hs
@@ -57,6 +57,5 @@ fakeConnection x' = do
     o <- Streams.nullOutput
     i <- Streams.fromByteString x'
 
-    c <- makeConnection "swift.example.com" (return ()) o i
+    let c = makeConnection "swift.example.com" (return ()) o i
     return c
-

--- a/tests/CurrentPoint.hs
+++ b/tests/CurrentPoint.hs
@@ -56,6 +56,5 @@ fakeConnection x' = do
     o <- Streams.nullOutput
     i <- Streams.fromByteString x'
 
-    c <- makeConnection "swift.example.com" (return ()) o i
+    let c = makeConnection "swift.example.com" (return ()) o i
     return c
-

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -110,8 +110,9 @@ suite = do
         testExcessiveRedirects
         testGeneralHandler
         testEstablishConnection
-        testParsingJson1
-        testParsingJson2
+        -- Andreas Abel, 2022-03-30: These test do not build:
+        -- testParsingJson1
+        -- testParsingJson2
 
     describe "Corner cases in protocol compliance" $ do
         testSendBodyFor PUT
@@ -165,7 +166,7 @@ fakeConnection :: IO Connection
 fakeConnection = do
     i <- Streams.nullInput
     o <- Streams.nullOutput
-    c <- makeConnection "www.example.com" (return ()) o i
+    let c = makeConnection "www.example.com" (return ()) o i
     return c
 
 
@@ -336,7 +337,7 @@ fakeConnectionHttp10 = do
     i <- Streams.fromByteString x'
 
     o <- Streams.nullOutput
-    c <- makeConnection "bad.example.com" (return ()) o i
+    let c = makeConnection "bad.example.com" (return ()) o i
     return c
 
 
@@ -382,7 +383,7 @@ fakeConnectionNoContent = do
     i3 <- Streams.concatInputStreams [i1, i2]
 
     o <- Streams.nullOutput
-    c <- makeConnection "worse.example.com" (return ()) o i3
+    let c = makeConnection "worse.example.com" (return ()) o i3
     return (c, mv)
   where
     blockOn :: MVar () -> IO (Maybe ByteString)
@@ -673,27 +674,29 @@ testEstablishConnection =
         let len = S.length x'
         assertEqual "Incorrect number of bytes read" 4611 len
 
+-- Andreas Abel, 2022-03-30:
+-- No 'jsonHandler' defined, unfortunately, so no testing it.
 
-testParsingJson1 =
-    it "GET with JSON handler behaves" $ do
-        let url = S.concat ["http://", localhost, "/static/data-eu-gdp.json"]
+-- testParsingJson1 =
+--     it "GET with JSON handler behaves" $ do
+--         let url = S.concat ["http://", localhost, "/static/data-eu-gdp.json"]
 
-        x <- get url jsonHandler
-        let (Object o) = x
-        let (Just v) = Map.lookup "label" o
-        let (String t) = v
+--         x <- get url jsonHandler
+--         let (Object o) = x
+--         let (Just v) = Map.lookup "label" o
+--         let (String t) = v
 
-        assertEqual "Incorrect response" "Europe (EU27)" t
+--         assertEqual "Incorrect response" "Europe (EU27)" t
 
-testParsingJson2 =
-    it "GET with JSON handler parses using Aeson" $ do
-        let url = S.concat ["http://", localhost, "/static/data-jp-gdp.json"]
+-- testParsingJson2 =
+--     it "GET with JSON handler parses using Aeson" $ do
+--         let url = S.concat ["http://", localhost, "/static/data-jp-gdp.json"]
 
-        x <- get url jsonHandler :: IO GrossDomesticProduct
+--         x <- get url jsonHandler :: IO GrossDomesticProduct
 
-        assertEqual "Incorrect response" "Japan" (gLabel x)
-        assertEqual "Data not parsed as expected" 2008 (fst $ last $ gData x)
---      L.putStr $ encodePretty x
+--         assertEqual "Incorrect response" "Japan" (gLabel x)
+--         assertEqual "Data not parsed as expected" 2008 (fst $ last $ gData x)
+-- --      L.putStr $ encodePretty x
 
 
 {-
@@ -718,4 +721,3 @@ instance ToJSON GrossDomesticProduct where
     toJSON (GrossDomesticProduct l d) = object
                                ["label" .= l,
                                 "data"  .= d]
-


### PR DESCRIPTION
Tests build only on GHC 7.6 - 8.10 atm.
- https://github.com/snapframework/snap/issues/222

Also fix these build errors:
- type of `makeConnection` became non-monadic
- `jsonHandler` not defined

Move common dependencies to `settings` stanza.

Fixes #5.