### PR TITLE
Test text-2.0 (fixes #4)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20220808
+# version: 0.15.20230128
 #
-# REGENDATA ("0.15.20220808",["github","http-io-streams.cabal"])
+# REGENDATA ("0.15.20230128",["github","http-io-streams.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,14 +34,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.1
+          - compiler: ghc-9.4.4
             compilerKind: ghc
-            compilerVersion: 9.4.1
+            compilerVersion: 9.4.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.2.5
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -109,8 +109,9 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
             apt-get update
             apt-get install -y libbrotli-dev
           else
@@ -120,7 +121,8 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -138,18 +140,18 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 70600 && HCNUMVER < 90000)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
+          if [ $((HCNUMVER >= 70600)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -203,7 +205,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -237,8 +239,8 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -255,15 +257,21 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          if [ $((HCNUMVER >= 70600 && HCNUMVER < 90000)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
+          if [ $((HCNUMVER >= 70600)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_http_io_streams} || false
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -151,7 +151,7 @@ jobs:
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 70600)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
+          if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -257,7 +257,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          if [ $((HCNUMVER >= 70600)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
+          if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_http_io_streams} || false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 See also http://pvp.haskell.org/faq
 
-#### 0.1.6.2
+### Unreleased
 
 * Run test-suite via `cabal test`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 See also http://pvp.haskell.org/faq
 
+### 0.1.6.2
+
+* Allow `text-2.0` (no code change).
+* Run test-suite via `cabal test`.
+
 ### 0.1.6.1
 
 * Build with GHC 9.2 and `ghc-prim-0.8` (via `base-4.16`).
@@ -7,7 +12,7 @@ See also http://pvp.haskell.org/faq
 ### 0.1.6.0
 
 * New function `openConnectionAddress''` supporting supplying local `SSLContext`s as well as modifying the `SSL` connection before initiating the client SSL handshake.
-* New function `openConnectionSSL'` which allows to customize the 'SSL' connection /before/ a client SSL handshake is attempted.
+* New function `openConnectionSSL'` which allows to customize the SSL connection _before_ a client SSL handshake is attempted.
 * New convenience function `getContextSSL` function allowing to retrieve global `SSLContext`.
 
 ### 0.1.5.0
@@ -21,21 +26,21 @@ See also http://pvp.haskell.org/faq
 
 ### 0.1.3.0
 
-* New functions `receiveUpgradeResponse`, 'receiveConnectResponse', and `unsafeWithRawStreams` for accessing full-duplex low-level streams (e.g. for upgrading to Websockets protocol
+* New functions `receiveUpgradeResponse`, `receiveConnectResponse`, and `unsafeWithRawStreams` for accessing full-duplex low-level streams (e.g. for upgrading to Websockets protocol).
 * New function `makeConnection` for constructing a `Connection` object over custom streams.
 
 ### 0.1.2.0
 
-* New functions `unsafeReceiveResponse` and `unsafeReceiveResponseRaw` that do not automatically skip to end-of-stream
+* New functions `unsafeReceiveResponse` and `unsafeReceiveResponseRaw` that do not automatically skip to end-of-stream.
 
 ### 0.1.1.0
 
-* New alternative connection-setup API (`ConnectionAddress` et al.)
-* New function `getHeaderMap` for exporting all response headers at once
-* Add convenience functions `bytestringBody`, `lazyBytestringBody`, `utf8TextBody`, `utf8LazyTextBody`
-* Add support for Brotli HTTP compression
+* New alternative connection-setup API (`ConnectionAddress` et al.).
+* New function `getHeaderMap` for exporting all response headers at once.
+* Add convenience functions `bytestringBody`, `lazyBytestringBody`, `utf8TextBody`, `utf8LazyTextBody`.
+* Add support for Brotli HTTP compression.
 
 ## 0.1.0.0
 
 * First version. Released on an unsuspecting world.
-* Derived from `http-streams-core-0.8.6.1` & `http-common-0.8.2.0`
+* Derived from `http-streams-core-0.8.6.1` & `http-common-0.8.2.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 See also http://pvp.haskell.org/faq
 
-### 0.1.6.2
+#### 0.1.6.2
 
-* Allow `text-2.0` (no code change).
 * Run test-suite via `cabal test`.
 
-### 0.1.6.1
+#### 0.1.6.1 revision 1
+
+* Allow `text-2.0` (no code change).
+
+#### 0.1.6.1
 
 * Build with GHC 9.2 and `ghc-prim-0.8` (via `base-4.16`).
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -5,6 +5,7 @@ branches: master ci*
 installed: -all
 
 -- Andreas Abel, 2022-03-30:
--- The `snap` framework does not build on GHC 9.x yet.
--- On GHC 7.4, it has conflicting constraints with the other dependencies.
-tests: >= 7.6
+-- On GHC 7.4, the `snap` framework it has conflicting constraints with the other dependencies.
+-- Andreas Ab1l, 2023-02-02:
+-- Weird compilation error for `snap` under GHC 7.6.
+tests: >= 7.8

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -7,4 +7,4 @@ installed: -all
 -- Andreas Abel, 2022-03-30:
 -- The `snap` framework does not build on GHC 9.x yet.
 -- On GHC 7.4, it has conflicting constraints with the other dependencies.
-tests: >= 7.6 && < 9.0
+tests: >= 7.6

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -6,6 +6,6 @@ installed: -all
 
 -- Andreas Abel, 2022-03-30:
 -- On GHC 7.4, the `snap` framework it has conflicting constraints with the other dependencies.
--- Andreas Ab1l, 2023-02-02:
+-- Andreas Abel, 2023-02-02:
 -- Weird compilation error for `snap` under GHC 7.6.
 tests: >= 7.8

--- a/http-io-streams.cabal
+++ b/http-io-streams.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                http-io-streams
-version:             0.1.6.1
+version:             0.1.6.2
 
 synopsis:            HTTP and WebSocket client based on io-streams
 description:
@@ -15,10 +15,10 @@ license:             BSD-3-Clause AND GPL-2.0-or-later
 license-files:       LICENSE LICENSE.GPLv2
 author:              Andrew Cowie <andrew@operationaldynamics.com>,
                      Herbert Valerio Riedel <hvr@gnu.org>
-maintainer:          Herbert Valerio Riedel <hvr@gnu.org>
+maintainer:          https://github.com/haskell-hvr/http-io-streams
 copyright:           © 2012-2018 Operational Dynamics Consulting, Pty Ltd and Others
 category:            Web, IO-Streams
-bug-reports:         https://github.com/hvr/http-io-streams/issues
+bug-reports:         https://github.com/haskell-hvr/http-io-streams/issues
 
 extra-source-files:
   CHANGELOG.md
@@ -47,7 +47,7 @@ tested-with:
 
 source-repository    head
   type:              git
-  location:          https://github.com/hvr/http-io-streams.git
+  location:          https://github.com/haskell-hvr/http-io-streams.git
 
 flag brotli
   manual:  True

--- a/http-io-streams.cabal
+++ b/http-io-streams.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                http-io-streams
-version:             0.1.6.2
+version:             0.1.6.1
 
 synopsis:            HTTP and WebSocket client based on io-streams
 description:

--- a/http-io-streams.cabal
+++ b/http-io-streams.cabal
@@ -31,8 +31,8 @@ extra-source-files:
   tests/statler.jpg
 
 tested-with:
-  GHC == 9.4.1
-  GHC == 9.2.4
+  GHC == 9.4.4
+  GHC == 9.2.5
   GHC == 9.0.2
   GHC == 8.10.7
   GHC == 8.8.4


### PR DESCRIPTION
Test`text-2.0` (fixes #4) on CI with GHC 7.8 - 9.4.
Also fixes to CHANGELOG.

OP:

Testing is blocked on:
- https://github.com/snapframework/snap-server/issues/147
- https://github.com/snapframework/heist/pull/132

Testing attempt `cabal build --enable-tests -w ghc-8.10.7 --constraint='text==2.*' --allow-newer='*:text' --constraint='hashable==1.4.*' --allow-newer='*:hashable' --constraint='attoparsec==0.14.*' --allow-newer='*:attoparsec' --constraint='aeson==1.5.*' --allow-newer='*:aeson'` failes at `aeson-1.5.6.0`.

Testing attempt `cabal build --enable-tests -w ghc-8.10.7 --constraint='text==2.*' --allow-newer='*:text' --constraint='hashable==1.4.*' --allow-newer='*:hashable' --constraint='attoparsec==0.14.*' --allow-newer='*:attoparsec' --constraint='aeson==2.0.*' --allow-newer='*:aeson'` failes at `heist-1.1.0.1`.