### PR TITLE
v0.1.6.2: Allow mtl-2.3 and base-4.18 (GHC 9.6)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -34,6 +34,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.6.0.20230111
+            compilerKind: ghc
+            compilerVersion: 9.6.0.20230111
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.4.4
             compilerKind: ghc
             compilerVersion: 9.4.4
@@ -153,7 +158,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -182,6 +187,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -233,6 +250,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -269,6 +289,13 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set mtl-2.3
+        run: |
+          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3.1' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3.1' all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230128
+# version: 0.15.20230203
 #
-# REGENDATA ("0.15.20230128",["github","http-io-streams.cabal"])
+# REGENDATA ("0.15.20230203",["github","http-io-streams.cabal"])
 #
 name: Haskell-CI
 on:
@@ -34,9 +34,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.0.20230111
+          - compiler: ghc-9.6.0.20230128
             compilerKind: ghc
-            compilerVersion: 9.6.0.20230111
+            compilerVersion: 9.6.0.20230128
             setup-method: ghcup
             allow-failure: true
           - compiler: ghc-9.4.4
@@ -156,7 +156,7 @@ jobs:
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
+          if [ $((HCNUMVER >= 70800 && HCNUMVER < 90600)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -277,7 +277,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          if [ $((HCNUMVER >= 70800)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
+          if [ $((HCNUMVER >= 70800 && HCNUMVER < 90600)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_http_io_streams} || false
@@ -294,8 +294,8 @@ jobs:
           rm -f cabal.project.local
       - name: constraint set mtl-2.3
         run: |
-          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3.1' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3.1' all ; fi
+          if [ $((HCNUMVER >= 80600 && HCNUMVER < 90000 || HCNUMVER >= 90200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3.1' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80600 && HCNUMVER < 90000 || HCNUMVER >= 90200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3.1' all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 See also http://pvp.haskell.org/faq
 
-### 0.1.6.2
+#### 0.1.6.2
 
 * Allow `mtl-2.3` (no code change).
 * Run test-suite via `cabal test`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 See also http://pvp.haskell.org/faq
 
-### Unreleased
+### 0.1.6.2
 
+* Allow `mtl-2.3` (no code change).
 * Run test-suite via `cabal test`.
+
+Tested with GHC 7.4 - 9.6.
 
 #### 0.1.6.1 revision 1
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -9,3 +9,8 @@ installed: -all
 -- Andreas Abel, 2023-02-02:
 -- Weird compilation error for `snap` under GHC 7.6.
 tests: >= 7.8
+
+constraint-set mtl-2.3
+  ghc: >= 8.6
+  constraints: mtl >= 2.3.1
+  tests: False

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -6,11 +6,15 @@ installed: -all
 
 -- Andreas Abel, 2022-03-30:
 -- On GHC 7.4, the `snap` framework it has conflicting constraints with the other dependencies.
--- Andreas Abel, 2023-02-02:
+-- 2023-02-02:
 -- Weird compilation error for `snap` under GHC 7.6.
-tests: >= 7.8
+-- 2023-02-03:
+-- `snap` does not build with GHC 9.6 yet.
+tests: >= 7.8 && < 9.5
 
 constraint-set mtl-2.3
-  ghc: >= 8.6
+  -- GHC 9.0 is excluded by mtl-2.3.1: https://github.com/haskell/mtl/issues/138
+  ghc: >= 8.6 && < 9 || >= 9.2.3
   constraints: mtl >= 2.3.1
-  tests: False
+  -- Tests are anyway disabled in "constraint-set" jobs.
+  -- tests: False

--- a/http-io-streams.cabal
+++ b/http-io-streams.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                http-io-streams
-version:             0.1.6.1
+version:             0.1.6.2
 
 synopsis:            HTTP and WebSocket client based on io-streams
 description:
@@ -31,6 +31,7 @@ extra-source-files:
   tests/statler.jpg
 
 tested-with:
+  GHC == 9.6.0
   GHC == 9.4.4
   GHC == 9.2.5
   GHC == 9.0.2
@@ -61,7 +62,7 @@ flag fast-xor
 
 common settings
   build-depends:
-    , base                 >= 4.5 && < 4.18
+    , base                 >= 4.5 && < 4.19
     , attoparsec          ^>= 0.13.2.2 || ^>= 0.14.4
     , base64-bytestring   ^>= 1.2.1.0
     , blaze-builder       ^>= 0.4.1.0
@@ -71,7 +72,7 @@ common settings
     , directory           ^>= 1.2.0.1 || ^>= 1.3.0.0
     , HsOpenSSL           ^>= 0.11.2
     , io-streams          ^>= 1.5.0.1
-    , mtl                 ^>= 2.2.2
+    , mtl                 ^>= 2.2.2   || ^>= 2.3.1
     , network             ^>= 2.6.0.0 || ^>= 2.7.0.0 || ^>= 2.8.0.0 || ^>= 3.0.0.0 || ^>= 3.1.0.0
     , network-uri         ^>= 2.6.0.0
     , openssl-streams     ^>= 1.2.1.3


### PR DESCRIPTION
Closes #9.

Hackage candidate: https://hackage.haskell.org/package/http-io-streams-0.1.6.2/candidate